### PR TITLE
Fix major invasion probe log directory creation

### DIFF
--- a/spec/empire/computer/threat_response_probe_spec.clj
+++ b/spec/empire/computer/threat_response_probe_spec.clj
@@ -1,0 +1,52 @@
+(ns empire.computer.threat-response-probe-spec
+  (:require [empire.computer.threat-response.probe :as probe]
+            [empire.test.utils :as test-utils]
+            [speclj.core :refer :all])
+  (:import [java.io File]
+           [java.nio.file Files]))
+
+(defn- nested-log-file
+  []
+  (let [base-dir (.toFile (Files/createTempDirectory "probe-spec-" (make-array java.nio.file.attribute.FileAttribute 0)))
+        nested-dir (File. base-dir "nested")
+        log-file (File. nested-dir "major-invasion-probe.log")]
+    (.deleteOnExit base-dir)
+    (.deleteOnExit nested-dir)
+    (.deleteOnExit log-file)
+    {:nested-dir nested-dir
+     :log-file log-file}))
+
+(defmacro with-log-path
+  [path & body]
+  `(let [original-path# @#'probe/log-path]
+     (alter-var-root #'probe/log-path (constantly ~path))
+     (try
+       ~@body
+       (finally
+         (alter-var-root #'probe/log-path (constantly original-path#))))))
+
+(describe "threat-response probe"
+  (before (test-utils/reset-all-atoms!))
+
+  (it "creates the log parent directory when clearing the log"
+    (let [{:keys [nested-dir log-file]} (nested-log-file)]
+      (with-log-path (.getPath log-file)
+        (probe/clear-log!))
+      (should (.exists nested-dir))
+      (should (.exists log-file))
+      (should= "" (slurp log-file))))
+
+  (it "creates the log parent directory when appending a log entry"
+    (let [{:keys [nested-dir log-file]} (nested-log-file)
+          world [[{:type :land
+                   :contents {:type :army
+                              :owner :player}}]]]
+      (test-utils/set-test-world! world)
+      (test-utils/set-test-computer-map! world)
+      (test-utils/set-test-state! :round-number 7)
+      (test-utils/set-test-state! :major-invasion-state {:active? false})
+      (with-log-path (.getPath log-file)
+        (probe/log-event! :major-invasion-activated {:source :spec}))
+      (should (.exists nested-dir))
+      (should (.exists log-file))
+      (should-contain "major-invasion-activated" (slurp log-file)))))

--- a/src/empire/computer/threat_response/probe.cljc
+++ b/src/empire/computer/threat_response/probe.cljc
@@ -1,12 +1,20 @@
 (ns empire.computer.threat-response.probe
-  (:require [clojure.string :as str]
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [empire.state.api :as sa]))
 
 (def ^:private log-path "target/major-invasion-probe.log")
 
+(defn- ensure-log-parent!
+  []
+  #?(:clj (io/make-parents (io/file log-path))
+     :cljs nil))
+
 (defn clear-log!
   []
-  #?(:clj (spit log-path "")
+  #?(:clj (do
+            (ensure-log-parent!)
+            (spit log-path ""))
      :cljs nil))
 
 (defn- stack-lines
@@ -66,7 +74,9 @@
 
 (defn log-event!
   [kind payload]
-  #?(:clj (spit log-path (format-entry kind payload) :append true)
+  #?(:clj (do
+            (ensure-log-parent!)
+            (spit log-path (format-entry kind payload) :append true))
      :cljs nil)
   (when (and (sa/read-state :headless-stop-on-major-invasion?)
              (not (sa/read-state :major-invasion-probe-hit?)))
@@ -77,5 +87,5 @@
                                      :cljs js/Number.MAX_SAFE_INTEGER))))
 
 ;; clj-mutate-manifest-begin
-;; {:version 1, :tested-at "2026-03-26T23:51:52.78161-05:00", :module-hash "-733822772", :forms [{:id "form/0/ns", :kind "ns", :line 1, :end-line 3, :hash "1499136211"} {:id "def/log-path", :kind "def", :line 5, :end-line 5, :hash "-444493232"} {:id "defn/clear-log!", :kind "defn", :line 7, :end-line 10, :hash "1467828463"} {:id "defn-/stack-lines", :kind "defn-", :line 12, :end-line 17, :hash "-85849438"} {:id "defn-/visible-player-evidence", :kind "defn-", :line 19, :end-line 32, :hash "-1205361268"} {:id "defn-/actual-player-evidence", :kind "defn-", :line 34, :end-line 47, :hash "-65330508"} {:id "defn-/format-entry", :kind "defn-", :line 49, :end-line 65, :hash "-1491768849"} {:id "defn/log-event!", :kind "defn", :line 67, :end-line 77, :hash "-1264928892"}]}
+;; {:version 1, :tested-at "2026-03-29T18:25:38.914556082-04:00", :module-hash "1198535082", :forms [{:id "form/0/ns", :kind "ns", :line 1, :end-line 4, :hash "1330868388"} {:id "def/log-path", :kind "def", :line 6, :end-line 6, :hash "-444493232"} {:id "defn-/ensure-log-parent!", :kind "defn-", :line 8, :end-line 11, :hash "1773186771"} {:id "defn/clear-log!", :kind "defn", :line 13, :end-line 18, :hash "62872133"} {:id "defn-/stack-lines", :kind "defn-", :line 20, :end-line 25, :hash "-85849438"} {:id "defn-/visible-player-evidence", :kind "defn-", :line 27, :end-line 40, :hash "-1205361268"} {:id "defn-/actual-player-evidence", :kind "defn-", :line 42, :end-line 55, :hash "-65330508"} {:id "defn-/format-entry", :kind "defn-", :line 57, :end-line 73, :hash "-1491768849"} {:id "defn/log-event!", :kind "defn", :line 75, :end-line 87, :hash "-1127165697"}]}
 ;; clj-mutate-manifest-end


### PR DESCRIPTION
Fixes #3

## Summary

Make the major invasion probe create the parent directory for `target/major-invasion-probe.log` before writing.

Without that, `clj -M:spec` fails on a clean checkout if `target/` does not already exist.

## Changes

- create the parent directory before probe log writes in `src/empire/computer/threat_response/probe.cljc`
- add a focused regression spec covering both `clear-log!` and `log-event!`

## Why this approach

The probe owns this file-writing side effect, so it should also own making the output path writable.

That is better than requiring tests or callers to pre-create `target/`, and it keeps the runtime path safe on a clean checkout.

## Validation

- `clj -M:spec-structure-check spec/empire/computer/threat_response_probe_spec.clj`
- `clj -M:spec spec/empire/computer/threat_response_probe_spec.clj`
- `clj -M:spec`
- `clj -M:crap src/empire/computer/threat_response/probe.cljc`
- `clj -M:mutate src/empire/computer/threat_response/probe.cljc --reuse-lcov --max-workers 3`

## Rights

I assign any rights I may have in this contribution to Robert C. Martin for inclusion in this project.
